### PR TITLE
Improve dashboard UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Dashboard</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <div class="sidebar">
@@ -19,23 +20,30 @@
       <span class="account">Account</span>
     </div>
     <div class="content">
+      <h1 class="page-title">Gestione Affitti</h1>
       <div class="stats">
-        <div class="stat-card">
-          <h3>Prenotazioni</h3>
-          <p id="totPren">-</p>
+        <div class="stat-card prenotazioni">
+          <i class="fa-solid fa-calendar-check stat-icon"></i>
+          <div class="stat-info">
+            <h3>Prenotazioni</h3>
+            <p id="totPren">-</p>
+          </div>
         </div>
-        <div class="stat-card">
-          <h3>Entrate</h3>
-          <p id="totEntrate">-</p>
+        <div class="stat-card entrate">
+          <i class="fa-solid fa-euro-sign stat-icon"></i>
+          <div class="stat-info">
+            <h3>Entrate</h3>
+            <p id="totEntrate">-</p>
+          </div>
         </div>
       </div>
       <div class="actions">
         <a class="btn" href="lista_prenotazioni.html">Lista Prenotazioni</a>
         <a class="btn" href="lista_movimenti.html">Lista Movimenti</a>
       </div>
-      <div class="card">
-        <h2>Prossimi Check-in</h2>
-        <button onclick="caricaDashboard()">Aggiorna</button>
+      <div class="card" id="checkin-card">
+        <h2>📅 Prossimi Check-in</h2>
+        <button class="btn" onclick="caricaDashboard()">Aggiorna</button>
         <div id="dashboard">Caricamento in corso...</div>
       </div>
     </div>
@@ -45,6 +53,12 @@
 
     function parseDate(iso) {
       return new Date(iso);
+    }
+
+    function formatDate(iso) {
+      const d = parseDate(iso);
+      if (isNaN(d)) return '';
+      return d.toLocaleDateString('it-IT');
     }
 
     async function caricaStatistiche() {
@@ -94,8 +108,8 @@
           html += '<tr>' +
             `<td>${row[idxApp] ?? ''}</td>` +
             `<td>${row[idxNome] ?? ''}</td>` +
-            `<td>${row[idxIn] ?? ''}</td>` +
-            `<td>${row[idxOut] ?? ''}</td>` +
+            `<td>${formatDate(row[idxIn])}</td>` +
+            `<td>${formatDate(row[idxOut])}</td>` +
             '</tr>';
         });
         html += '</tbody></table>';

--- a/style.css
+++ b/style.css
@@ -24,8 +24,9 @@ body {
 
 .sidebar h2 {
   margin-top: 0;
-  font-size: 20px;
+  font-size: 24px;
   color: #fff;
+  text-align: center;
 }
 
 .sidebar ul {
@@ -77,29 +78,58 @@ body {
 
 .stat-card {
   flex: 1;
-  min-width: 180px;
+  min-width: 200px;
   background: #fff;
-  padding: 15px;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  display: flex;
+  align-items: center;
+  color: #fff;
+}
+
+.stat-card .stat-icon {
+  font-size: 32px;
+  margin-right: 15px;
 }
 
 .stat-card h3 {
-  margin-top: 0;
-  color: #1877f2;
+  margin: 0;
+  font-size: 18px;
+  color: #fff;
+}
+
+.stat-card p {
+  margin: 5px 0 0 0;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.stat-card.prenotazioni {
+  background-color: #1abc9c;
+}
+
+.stat-card.entrate {
+  background-color: #f39c12;
+}
+
+.stat-info {
+  display: flex;
+  flex-direction: column;
 }
 
 .btn {
   background-color: #1877F2;
   color: #fff;
   border: none;
-  padding: 10px 20px;
+  padding: 10px 25px;
   margin: 5px;
   cursor: pointer;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 25px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-decoration: none;
   display: inline-block;
+  font-weight: 600;
 }
 
 .btn:hover {
@@ -117,6 +147,17 @@ body {
 h1, h2 {
   color: #1877F2;
   margin-top: 0;
+}
+
+.page-title {
+  text-align: center;
+  margin-bottom: 20px;
+  font-size: 28px;
+}
+
+.actions {
+  text-align: center;
+  margin: 10px 0 30px 0;
 }
 
 table {


### PR DESCRIPTION
## Summary
- restyle home page with dashboard title and cards
- colorized stat cards with icons
- prettier rounded buttons and centered actions
- show upcoming check-in dates in `dd/mm/yyyy` format

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685b035864ac8333a1af602fe68a9198